### PR TITLE
Add installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ $ ./selfprofiler.sh > prof.json
 
 In Google Chrome navigate to `about://tracing` and load `prof.json`.
 
+## Installation
+If you would like to install SelfProfiler globally so that you can run it in any directory, you can use `install.sh`.
+
+```sh
+$ ./install.sh
+```
+
+Please restart your terminal or source your environment file after installation is successful.
+
+Now you can run SelfProfiler in any directory.
+
+```sh
+$ selfprofiler > prof.json
+```
+
+Notes:
+- Please make sure `/usr/local/bin` is included in your environment path.
+
+- If you get `permission denied` error message while running `install.sh`, make sure it is executable. You can use the following command to make it executable. _(`sudo` might be required)_
+
+  ```sh
+  $ chmod +x ./install.sh
+  ```
+
 ## Example
 Here is an example [profiling output](./example/prof.json?raw=true) which when loaded in Google Chrome's Trace Event Profiling Tool looks as follows:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+PREFIX="/usr/local"
+
+mkdir -p $PREFIX/bin || (mkdir $PREFIX; mkdir $PREFIX/bin)
+cp ./selfprofiler.sh $PREFIX/bin
+mv $PREFIX/bin/selfprofiler.sh $PREFIX/bin/selfprofiler
+
+echo selfprofiler installed successfully.


### PR DESCRIPTION
- Allow users to run `selfprofiler` in any directory.
- Basically copy the script (`selfprofiler.sh`) under the path `/usr/local/bin`. This path is usually included by default in environment variables.