### PR TITLE
Escape name for proper JSON output

### DIFF
--- a/selfprofiler.sh
+++ b/selfprofiler.sh
@@ -28,9 +28,9 @@ fi
 
 print_row() {
     app=$(echo $1 | awk -F', ' '{print $1}')
-    label=$(echo $1 | awk -F', ' '{print $2}')
+    label=$(echo $1 | awk -F', ' '{print $2}' | jq -aR)
     ph=$2
-    echo '{"name": "'$label'", "cat": "'$app'", "ph": "'$ph'", "pid": "HUMAN", "tid": "'$app'", "ts": '$timestamp'},'
+    echo '{"name": '$label', "cat": "'$app'", "ph": "'$ph'", "pid": "HUMAN", "tid": "'$app'", "ts": '$timestamp'},'
 }
 
 timestamp=0


### PR DESCRIPTION
If you visit e.g. a tweet (https://twitter.com/SwiftOnSecurity/status/1041412775577354240)
then you get quotes in the title which will make the JSON output improper.